### PR TITLE
some initial thoughts on the organization of this project

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = inventory
+gathering = smart
+
+[privilege_escalation]
+become = true

--- a/deployment-example.yaml
+++ b/deployment-example.yaml
@@ -1,10 +1,5 @@
 ---
 - hosts: controllers
-  become: yes
   roles:
-    - common
-    - mysql
-    - keystone
+    - profile/controller
     - puppet_run
-  vars:
-    puppet_role: controller

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - puppet

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -1,29 +1,6 @@
 ---
 # this playbook is common to all nodes.
 
-##################
-# install puppet #
-##################
-- name: install puppetlabs-release
-  yum: name=https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm state=present
-
-- name: install epel
-  yum: name=epel-release state=present
-
-- name: puppet and dependencies
-  yum: name={{ item }} state=latest
-  with_items:
-    - libxml2-devel
-    - libxslt-devel
-    - puppet
-    - python-pip
-    - ruby-devel
-    - rubygems
-    - wget
-
-- name: install the 'Development tools' package group
-  yum: name="@Development tools" state=present
-
 - name: configure hiera.yaml
   blockinfile:
     dest: /etc/puppet/hiera.yaml
@@ -42,7 +19,9 @@
 # puppet manifest #
 ###################
 - name: create /etc/puppet/manifests
-  file: path=/etc/puppet/manifests state=directory
+  file:
+    path: /etc/puppet/manifests
+    state: directory
 
 - name: create site.pp
   blockinfile:
@@ -58,10 +37,14 @@
 # puppet data #
 ###############
 - name: cleanup /etc/puppet/hieradata
-  file: path=/etc/puppet/hieradata state=absent
+  file:
+    path: /etc/puppet/hieradata
+    state: absent
 
 - name: create /etc/puppet/hieradata
-  file: path=/etc/puppet/hieradata state=directory
+  file:
+    path: /etc/puppet/hieradata
+    state: directory
 
 - name: create hieradata/common
   blockinfile:
@@ -74,7 +57,9 @@
         - openstack_integration::repos
 
 - name: create /etc/puppet/hieradata/{{ puppet_role }}
-  file: path=/etc/puppet/hieradata/{{ puppet_role }} state=directory
+  file:
+    path: /etc/puppet/hieradata/{{ puppet_role }}
+    state: directory
 
 - name: create hieradata/{{ puppet_role }}/common
   blockinfile:
@@ -99,7 +84,9 @@
   failed_when: "hiera_result.rc != 0"
 
 - name: create /etc/facter/facts.d
-  file: path=/etc/facter/facts.d state=directory
+  file:
+    path: /etc/facter/facts.d
+    state: directory
 
 - name: create facter environment
   blockinfile:
@@ -107,19 +94,4 @@
     create: yes
     block: |
       role={{ puppet_role }}
-
-##################
-# puppet modules #
-##################
-- name: install r10k
-  gem: name=r10k user_install=no
-
-- name: download Puppetfile
-  get_url: url=https://raw.githubusercontent.com/openstack/puppet-openstack-integration/master/Puppetfile dest=/tmp/Puppetfile
-
-- name: deploy puppet modules
-  shell: /usr/local/bin/r10k puppetfile install -v
-  environment:
-    PUPPETFILE_DIR: /etc/puppet/modules
-    PUPPETFILE: /tmp/Puppetfile
 

--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: install EPEL
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    state: installed

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - shade

--- a/roles/mysql/tasks/main.yaml
+++ b/roles/mysql/tasks/main.yaml
@@ -9,6 +9,8 @@
         - openstack_integration::mysql
 
 - name: validate mysql is working
-  mysql_db: name=dbtest state=present
+  mysql_db:
+    name: dbtest
+    state: present
   tags:
     - validation

--- a/roles/profile/compute/vars/main.yml
+++ b/roles/profile/compute/vars/main.yml
@@ -1,0 +1,1 @@
+puppet_role: compute

--- a/roles/profile/controller/meta/main.yml
+++ b/roles/profile/controller/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - common
+  - mysql
+  - keystone

--- a/roles/profile/controller/vars/main.yml
+++ b/roles/profile/controller/vars/main.yml
@@ -1,0 +1,1 @@
+puppet_role: controller

--- a/roles/puppet/meta/main.yml
+++ b/roles/puppet/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  # we need epel for python-pip
+  - epel

--- a/roles/puppet/tasks/main.yml
+++ b/roles/puppet/tasks/main.yml
@@ -1,0 +1,37 @@
+- name: install puppetlabs-release
+  yum:
+    name: https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+    state: present
+
+- name: puppet and dependencies
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - libxml2-devel
+    - libxslt-devel
+    - puppet
+    - python-pip
+    - ruby-devel
+    - rubygems
+    - wget
+
+- name: install the 'Development tools' package group
+  yum: name="@Development tools" state=present
+
+- name: install r10k
+  gem:
+    name: r10k
+    user_install: no
+
+- name: download Puppetfile
+  get_url:
+    url: https://raw.githubusercontent.com/openstack/puppet-openstack-integration/master/Puppetfile
+    dest: /tmp/Puppetfile
+
+- name: deploy puppet modules
+  shell: /usr/local/bin/r10k puppetfile install -v
+  environment:
+    PUPPETFILE_DIR: /etc/puppet/modules
+    PUPPETFILE: /tmp/Puppetfile
+

--- a/roles/python-devel/tasks/main.yml
+++ b/roles/python-devel/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: install python development components
+  yum:
+    name: python-devel
+    state: installed

--- a/roles/shade/meta/main.yml
+++ b/roles/shade/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - python-devel

--- a/roles/shade/tasks/main.yml
+++ b/roles/shade/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: install shade
+  pip: name=shade
+  tags:
+    - validation


### PR DESCRIPTION
Rather than making the choice of role *explicit*, as in the existing
example, this makes the puppet role *implict* based on the ansible role
selected.  In this model, your top-level playbook could have:

    roles:
      - profile/controller

Or:

    roles:
      - profile/compute

And so forth to select between different host roles. Dependencies (e.g.,
for the `common` role that is required everywhere) are handled via
Ansible's role metadata support (`roles/<rolename>/meta/main.yml`)

It's also nice to make things reasonably granular...e.g., have roles
that *require* puppet depend on a role that is responsible for install
it.  This just helps keep playbooks focused.

With these changes, the example deployment playbook becomes:

    - hosts: controllers
      roles:
        - profile/controller
        - puppet_run