### PR TITLE
nested roles for grouping install/validation

### DIFF
--- a/deployment-example.yaml
+++ b/deployment-example.yaml
@@ -3,7 +3,10 @@
   roles:
     - profile/controller
 
-# keep it at the end so we run puppet at the very end.
 - hosts: all
   roles:
-    - puppet-run
+    - puppet_run
+
+- hosts: controllers
+  roles:
+    - profile/controller/validate

--- a/roles/keystone/install/meta/main.yml
+++ b/roles/keystone/install/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - keystone

--- a/roles/keystone/install/tasks/main.yaml
+++ b/roles/keystone/install/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: include keystone hiera snippet
+  blockinfile:
+    dest: /etc/puppet/hieradata/controller/common.yaml
+    marker: "# keystone class #"
+    insertafter: 'classes:'
+    block: |
+        - openstack_integration::keystone

--- a/roles/keystone/validate/meta/main.yml
+++ b/roles/keystone/validate/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
+  - keystone
   - shade

--- a/roles/keystone/validate/tasks/main.yaml
+++ b/roles/keystone/validate/tasks/main.yaml
@@ -1,23 +1,6 @@
 ---
-
-- name: include keystone puppet classes in hiera common
-  blockinfile:
-    dest: /etc/puppet/hieradata/common.yaml
-    marker: "# keystone class #"
-    insertafter: 'classes:'
-    block: |
-      # deploy keystone server
-        - openstack_integration::keystone
-
-- name: install shade
-  pip: name=shade
-  tags:
-    - validation
-
 - name: create /etc/openstack
   file: path=/etc/openstack state=directory
-  tags:
-    - validation
 
 - name: generate clouds.yaml
   blockinfile:
@@ -32,12 +15,7 @@
             username: admin
             password: a_big_secret
           region_name: RegionOne
-  tags:
-    - validation
-
 
 - name: validate keystone is working
   os_auth:
     cloud: openstack
-  tags:
-    - validation

--- a/roles/mysql/install/meta/main.yml
+++ b/roles/mysql/install/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - mysql

--- a/roles/mysql/install/tasks/main.yaml
+++ b/roles/mysql/install/tasks/main.yaml
@@ -1,6 +1,5 @@
 ---
-
-- name: include mysql puppet classes in hiera common
+- name: include mysql hiera snippet
   blockinfile:
     dest: /etc/puppet/hieradata/common.yaml
     marker: "# mysql class #"
@@ -8,10 +7,3 @@
     block: |
       # deploy mysql server
         - openstack_integration::mysql
-
-- name: validate mysql is working
-  mysql_db:
-    name: dbtest
-    state: present
-  tags:
-    - validation

--- a/roles/mysql/validate/meta/main.yml
+++ b/roles/mysql/validate/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - mysql

--- a/roles/mysql/validate/tasks/main.yml
+++ b/roles/mysql/validate/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: validate mysql is working
+  mysql_db:
+    name: dbtest
+    state: present

--- a/roles/profile/controller/meta/main.yml
+++ b/roles/profile/controller/meta/main.yml
@@ -1,4 +1,4 @@
 dependencies:
   - common
-  - mysql
-  - keystone
+  - mysql/install
+  - keystone/install

--- a/roles/profile/controller/validate/meta/main.yml
+++ b/roles/profile/controller/validate/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - mysql/validate
+  - keystone/validate

--- a/roles/shade/tasks/main.yml
+++ b/roles/shade/tasks/main.yml
@@ -1,4 +1,2 @@
 - name: install shade
   pip: name=shade
-  tags:
-    - validation


### PR DESCRIPTION
This is the sort of layout I was suggesting earlier today.  The
general idea is that for each component you have a top level role
(e.g, "mysql") that contains any default settings:

    roles/mysql/defaults/main.yml

And then you have separate /install and /validate roles:

    roles/mysql/install/tasks/main.yml

    roles/mysql/validate/tasks/main.yml

Each of these includes the parent role as a dependency in
meta/main.yml, e.g.:

    $ cat roles/mysql/install/meta/main.yml
    dependencies:
      - mysql

This lets you put common settings (or tasks, etc) in one place while
still separating out the validation steps.